### PR TITLE
Refactor map modules

### DIFF
--- a/lib/purgecss-webpack-plugin.es.js
+++ b/lib/purgecss-webpack-plugin.es.js
@@ -141,7 +141,7 @@ var files = function files(chunk) {
     var getter = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function (a) {
         return a;
     };
-    return chunk.mapModules(function (module) {
+    return chunk.modules.map(function (module) {
         var file = getter(module);
         if (!file) return null;
         return extensions.indexOf(path.extname(file)) >= 0 && file;

--- a/lib/purgecss-webpack-plugin.js
+++ b/lib/purgecss-webpack-plugin.js
@@ -145,7 +145,7 @@ var files = function files(chunk) {
     var getter = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function (a) {
         return a;
     };
-    return chunk.mapModules(function (module) {
+    return chunk.modules.map(function (module) {
         var file = getter(module);
         if (!file) return null;
         return extensions.indexOf(path.extname(file)) >= 0 && file;

--- a/src/search.js
+++ b/src/search.js
@@ -20,7 +20,7 @@ export const assets = (assets = [], extensions = []) =>
 
 export const files = (chunk, extensions = [], getter = a => a) =>
     chunk
-        .mapModules(module => {
+        .modules.map(module => {
             const file = getter(module)
             if (!file) return null
             return extensions.indexOf(path.extname(file)) >= 0 && file

--- a/src/search.js
+++ b/src/search.js
@@ -19,8 +19,8 @@ export const assets = (assets = [], extensions = []) =>
         .filter(a => a)
 
 export const files = (chunk, extensions = [], getter = a => a) =>
-    chunk
-        .modules.map(module => {
+    chunk.modules
+        .map(module => {
             const file = getter(module)
             if (!file) return null
             return extensions.indexOf(path.extname(file)) >= 0 && file


### PR DESCRIPTION
## Proposed changes

use `chunk.modules.map` instead of `chunk.mapModules`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Further comments

This should fix the issues 
https://github.com/FullHuman/purgecss-webpack-plugin/issues/11
and
https://github.com/FullHuman/purgecss/issues/46


I used the webpack documentation as reference
https://webpack.js.org/contribute/plugin-patterns/#exploring-assets-chunks-modules-and-dependencies
