### PR TITLE
Remove webpack-cli from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "webpack-sources": "^1.2.0"
   },
   "peerDependencies": {
-    "webpack": "^4 || ^3",
-    "webpack-cli": "^3"
+    "webpack": "^4 || ^3"
   }
 }


### PR DESCRIPTION
Closes #40

## Proposed changes

Remove webpack-cli from peerDependencies. It isn't needed as a peer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)