### PR TITLE
Consider rejected option

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ new PurgecssPlugin({
 })
 ```
 
+* #### rejected
+
+If `true` all removed selectors are added to the [Stats Data](https://webpack.js.org/api/stats/) as `purged`.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/lib/purgecss-webpack-plugin.js
+++ b/lib/purgecss-webpack-plugin.js
@@ -159,6 +159,7 @@ var files = function files(chunk) {
 var webpackVersion = 4;
 var styleExtensions = ['.css', '.scss', '.styl', '.sass', '.less'];
 var pluginName = 'PurgeCSS';
+var purgedStats = {};
 
 var PurgecssPlugin =
 /*#__PURE__*/
@@ -182,10 +183,25 @@ function () {
         compiler.hooks.compilation.tap(pluginName, function (compilation) {
           _this.initializePlugin(compilation);
         });
+        compiler.hooks.done.tapAsync(pluginName, function (stats, cb) {
+          _this.addStats(stats);
+
+          cb();
+        });
       } else {
         compiler.plugin('this-compilation', function (compilation) {
           _this.initializePlugin(compilation);
         });
+        compiler.plugin('done', function (stats) {
+          _this.addStats(stats);
+        });
+      }
+    }
+  }, {
+    key: "addStats",
+    value: function addStats(stats) {
+      if (this.options.rejected) {
+        stats.purged = purgedStats;
       }
     }
   }, {
@@ -263,7 +279,13 @@ function () {
           }
 
           var purgecss = new Purgecss(options);
-          compilation.assets[name] = new webpackSources.ConcatSource(purgecss.purge()[0].css);
+          var purged = purgecss.purge()[0];
+
+          if (purged.rejected) {
+            purgedStats[name] = purged.rejected;
+          }
+
+          compilation.assets[name] = new webpackSources.ConcatSource(purged.css);
         });
       });
       callback();


### PR DESCRIPTION
## Proposed changes

This PR adds proper support of the `rejected` option by adding the result (the removed selectors) to the stats data. Before this change the information was not accessible for debugging.

## Types of changes

What types of changes does your code introduce to purgecss-webpack-plugin?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Fixes https://github.com/FullHuman/purgecss-webpack-plugin/issues/57
